### PR TITLE
expose less global variables

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -20,10 +20,6 @@
 
 	"globals": {
 		"define": true,
-        "mimefuncs" : true,
-        "mimetypes" : true,
-        "punycode" : true,
-        "addressparser" : true,
         "console": true,
 		"describe": true,
 		"it": true,

--- a/src/mailbuild.js
+++ b/src/mailbuild.js
@@ -26,7 +26,7 @@
     } else if (typeof exports === 'object') {
         module.exports = factory(require('mimefuncs'), require('mimetypes'), require('punycode'), require('wo-addressparser'));
     } else {
-        root.mailbuild = factory(mimefuncs, mimetypes, punycode, addressparser);
+        root.mailbuild = factory(root.mimefuncs, root.mimetypes, root.punycode, root.addressparser);
     }
 }(this, function(mimefuncs, mimetypes, punycode, addressparser) {
     'use strict';


### PR DESCRIPTION
some dependencies are exposed as global variables, also this is not needed. Those should be exposed via the current context, instead.

This also changes the `.jshintrc` to make sure, this is the only place, those global variables are used.